### PR TITLE
canopy performance improvements

### DIFF
--- a/Dojo/Canopy2048/Canopy2048.fsproj
+++ b/Dojo/Canopy2048/Canopy2048.fsproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="canopy">
-      <HintPath>packages\canopy.0.9.8\lib\canopy.dll</HintPath>
+      <HintPath>packages\canopy.0.9.14\lib\canopy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -47,11 +47,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>packages\Newtonsoft.Json.5.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SizSelCsZzz">
-      <HintPath>packages\SizSelCsZzz.0.3.35.0\lib\SizSelCsZzz.dll</HintPath>
+      <HintPath>packages\SizSelCsZzz.0.3.36.0\lib\SizSelCsZzz.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -59,11 +59,11 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
     <Reference Include="WebDriver">
-      <HintPath>packages\Selenium.WebDriver.2.41.0\lib\net40\WebDriver.dll</HintPath>
+      <HintPath>packages\Selenium.WebDriver.2.42.0\lib\net40\WebDriver.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WebDriver.Support">
-      <HintPath>packages\Selenium.Support.2.41.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <HintPath>packages\Selenium.Support.2.42.0\lib\net40\WebDriver.Support.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/Dojo/Canopy2048/Interactions.fs
+++ b/Dojo/Canopy2048/Interactions.fs
@@ -5,13 +5,22 @@ open runner
 
 module Interactions =
 
-    let lost () =
-        match someElement ".game-message.game-over" with
+    let lostSelector = css ".game-message.game-over"
+    let winSelector = css ".game-message.game-won"
+    let gameOverSelector = css ".game-message.game-won, .game-message.game-over"
+
+    let lost () =        
+        match someElement <| lostSelector with
+        | None -> false
+        | Some(_) -> true
+        
+    let won () =        
+        match someElement <| winSelector with
         | None -> false
         | Some(_) -> true
 
-    let won () =
-        match someElement ".game-message.game-won" with
+    let gameEnded () =
+        match someElement <| gameOverSelector with
         | None -> false
         | Some(_) -> true
 

--- a/Dojo/Canopy2048/Program.fs
+++ b/Dojo/Canopy2048/Program.fs
@@ -39,6 +39,9 @@ open Interactions
 
 module program = 
 
+    canopy.configuration.optimizeBySkippingIFrameCheck <- true
+    canopy.configuration.optimizeByDisablingCoverageReport <- true
+
     "starting a game of 2048" &&& fun _ ->
 
         printfn "Game started."

--- a/Dojo/Canopy2048/packages.config
+++ b/Dojo/Canopy2048/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="canopy" version="0.9.8" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="5.0.1" targetFramework="net40" />
-  <package id="Selenium.Support" version="2.41.0" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.41.0" targetFramework="net40" />
-  <package id="SizSelCsZzz" version="0.3.35.0" targetFramework="net40" />
+  <package id="canopy" version="0.9.14" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
+  <package id="Selenium.Support" version="2.42.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.42.0" targetFramework="net40" />
+  <package id="SizSelCsZzz" version="0.3.36.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
@sergey-tihon Found that canopy was not performing as well as it could for the 2048 Dojo.  Because you check to see if the game has ended on each loop, and 99% of the time its expected to not have ended, exhaustively checking all types of selectors is a waste of time.  He and I talked in this ticket: https://github.com/lefthandedgoat/canopy/issues/163#issuecomment-54757613 and decided to add hints to canopy so that you could tell canopy to opt out of the whole list of finders and only use a specific one.  This helped out significantly.

I originally forked Sergey's copy of the dojo and it was taking about 10 seconds to make 15 decisions.   With optimizations in place it could do 60 decisions (and plays) in 10 seconds.  The increases are very obvious for the faster algorithms.  The more intelligent algorithms spend more time analyzing the board, so the improvements are not as obvious.  I had originally tested against @mathias-brandewinder canopy-2048 project and observed this.  Hope this PR makes the dojo more fun!

Great dojo by the way!